### PR TITLE
Shout result for easy debugging.

### DIFF
--- a/irgsh-node.conf
+++ b/irgsh-node.conf
@@ -1,4 +1,5 @@
 [irgsh]
+webhost = irgsh.blankonlinux.or.id
 server = https://irgsh.blankonlinux.or.id:8443/
 keyring = data/blankon-archive-keyring.gpg
 node-name = pabrik

--- a/irgsh_node/conf/__init__.py
+++ b/irgsh_node/conf/__init__.py
@@ -26,6 +26,7 @@ CONFIG_MAPPING = {
         'workers': 'CELERYD_CONCURRENCY',
         'db': 'LOCAL_DATABASE',
         'keyring': 'KEYRING',
+        'webhost': 'WEBHOST',
     },
     'queue': {
         'host': 'BROKER_HOST',

--- a/irgsh_node/manager.py
+++ b/irgsh_node/manager.py
@@ -68,8 +68,9 @@ def claim_task(task_id):
 def get_spec_status(spec_id):
     host = settings.SERVER.rstrip('/')
     url = URL_GET_STATUS % {'host': host, 'spec_id': spec_id}
-
-    return json.loads(send_message(url))
+    result = send_message(url)
+    print result
+    return json.loads(result)
 
 def ping():
     host = settings.SERVER.rstrip('/')

--- a/irgsh_node/tasks.py
+++ b/irgsh_node/tasks.py
@@ -85,6 +85,7 @@ class BuildPackage(Task):
                            arch=pbuilder_arch)
 
         # Build package
+        specification.source = specification.source.replace('irgsh.blankonlinux.or.id', settings.WEBHOST)
         clog.info('Building package %s for %s' % (specification.source,
                                                   distribution.name))
 

--- a/irgsh_node/utils.py
+++ b/irgsh_node/utils.py
@@ -50,5 +50,8 @@ def send_message(url, param=None):
 
     # Create request
     request = urllib2.Request(url, data, headers)
-    return opener.open(request).read()
+    try:
+       return opener.open(request).read()
+    except urllib2.HTTPError, e:
+       print e
 


### PR DESCRIPTION
When the error raised, we do not know makes taskinit waited too long for a builder. 